### PR TITLE
M3b.0: Android acceptance, native builds in CI and an honest matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,65 @@ jobs:
         working-directory: core
         run: cargo test --workspace --locked
 
+  bridge-macos:
+    name: Flutter bridge (macOS)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: 3.44.1
+          channel: stable
+          cache: true
+      - name: Install toolchain from rust-toolchain.toml
+        working-directory: core
+        run: rustup show
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: core
+      - name: Resolve packages
+        working-directory: clients/flutter
+        run: flutter pub get
+      - name: Analyze
+        working-directory: clients/flutter
+        run: flutter analyze
+      # The application links the Rust adapter, so this builds SQLCipher and
+      # its vendored OpenSSL for the host as well.
+      - name: Build
+        working-directory: clients/flutter
+        run: flutter build macos --debug
+
+  bridge-android:
+    name: Flutter bridge (Android)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: 3.44.1
+          channel: stable
+          cache: true
+      - name: Install toolchain from rust-toolchain.toml
+        working-directory: core
+        run: rustup show
+      - name: Add Android targets
+        run: rustup target add aarch64-linux-android x86_64-linux-android
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: core
+      - name: Resolve packages
+        working-directory: clients/flutter
+        run: flutter pub get
+      # One ABI keeps the vendored OpenSSL build to a single pass; the
+      # release matrix is a packaging concern for M3b.5.
+      - name: Build
+        working-directory: clients/flutter
+        run: flutter build apk --debug --target-platform android-arm64
+
   mls-spike:
     name: MLS spike (M0.5)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,9 @@ jobs:
       - name: Analyze
         working-directory: clients/flutter
         run: flutter analyze
+      - name: Widget tests
+        working-directory: clients/flutter
+        run: flutter test test
       # The application links the Rust adapter, so this builds SQLCipher and
       # its vendored OpenSSL for the host as well.
       - name: Build

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Arveil
 
-**Client update:** the reusable `arveil-app` layer, cooperative profile executor, resumable linking and process lock are implemented locally. Flutter is selected for all five client platforms, with macOS and Android first; no GUI or Dart/Rust bridge exists yet. See the [implementation record](docs/CLIENT_FOUNDATION.md), [Flutter plan](docs/PHASE3B.md) and [ADR-009](docs/adr/ADR-009-flutter-first.md).
+**Client update:** the reusable `arveil-app` layer, cooperative profile executor, resumable linking and process lock are implemented locally. Flutter is selected for all five client platforms, with macOS and Android first. The bridge and a technical client exist: a profile opens, answers a query and closes, verified on macOS. There is no messaging interface yet. See the [implementation record](docs/CLIENT_FOUNDATION.md), [Flutter plan](docs/PHASE3B.md) and [ADR-009](docs/adr/ADR-009-flutter-first.md).
 
 **A self-hosted, end-to-end encrypted messenger for families and small circles of trust.**
 One Go binary, one SQLite file, one data directory. Runs on a Raspberry Pi in your home and stays reachable over LAN, Tailscale, or a Cloudflare Tunnel, without changing a single security guarantee.

--- a/clients/flutter/README.md
+++ b/clients/flutter/README.md
@@ -1,17 +1,51 @@
-# arveil
+# Arveil client
 
-A new Flutter project.
+The Flutter client for [Arveil](../../README.md). It calls the Rust
+application layer through `core/crates/arveil-flutter`, a thin adapter
+generated with flutter_rust_bridge; identity, MLS, delivery and persistence
+stay in Rust, and this project holds navigation, presentation and screen
+state only ([ADR-009](../../docs/adr/ADR-009-flutter-first.md)).
 
-## Getting Started
+## What exists today
 
-This project is a starting point for a Flutter application.
+A profile opens with an explicit key, answers a query and closes. That is
+the whole surface: enrollment, pairing, conversation, attachments and
+device management belong to later milestones of the
+[phase 3b plan](../../docs/PHASE3B.md). The screen is a technical one, not
+a design.
 
-A few resources to get you started if this is your first Flutter project:
+## Running it
 
-- [Learn Flutter](https://docs.flutter.dev/get-started/learn-flutter)
-- [Write your first Flutter app](https://docs.flutter.dev/get-started/codelab)
-- [Flutter learning resources](https://docs.flutter.dev/reference/learning-resources)
+```bash
+flutter pub get
+flutter run -d macos
+```
 
-For help getting started with Flutter development, view the
-[online documentation](https://docs.flutter.dev/), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
+The pinned toolchain and the platform matrix live in
+[docs/PLATFORMS.md](../../docs/PLATFORMS.md). The native library is built by
+`rust_builder`, which points at the adapter crate; there is nothing to build
+by hand.
+
+## Acceptance
+
+```bash
+flutter analyze
+flutter test integration_test/profile_test.dart -d macos
+```
+
+`integration_test/profile_test.dart` is the M3b.0 acceptance flow, and it
+runs on the device rather than in a test harness: explicit key, typed query
+failure, refusal of a second session, malformed key, close, reopen, wrong
+key. Run it on Android with `-d <device>` once an emulator or a phone is
+attached.
+
+## Regenerating the bindings
+
+After changing the Rust API, from `core/crates/arveil-flutter`:
+
+```bash
+flutter_rust_bridge_codegen generate
+```
+
+Both the Rust and the Dart generated files are committed, so a review sees
+what the generator produced.

--- a/clients/flutter/test/widget_test.dart
+++ b/clients/flutter/test/widget_test.dart
@@ -1,30 +1,18 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
+// The technical screen before anything is opened. Pressing its buttons
+// needs the Rust library, so that flow lives in the integration test that
+// runs on a device; this one only checks what the screen says at rest.
+import 'package:arveil/main.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:arveil/main.dart';
-
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+  testWidgets('the screen starts with no profile open', (tester) async {
+    await tester.pumpWidget(const ArveilApp());
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    expect(find.byKey(const Key('status')), findsOneWidget);
+    expect(find.text('no profile open'), findsOneWidget);
+    expect(find.widgetWithText(FilledButton, 'Open'), findsOneWidget);
+    expect(find.widgetWithText(FilledButton, 'Conversations'), findsOneWidget);
+    expect(find.widgetWithText(FilledButton, 'Close'), findsOneWidget);
   });
 }

--- a/docs/CLIENT_FOUNDATION.md
+++ b/docs/CLIENT_FOUNDATION.md
@@ -4,7 +4,7 @@ Status: local implementation reviewed during the September 5, 2026 iterations. T
 
 ## Architecture and evidence
 
-CLI → `arveil-app` → `arveil-core`; the planned Flutter/bridge will call the same application layer. `arveil-app` coordinates operations and returns structured results; core retains identity, MLS, persistence and delivery primitives. Noise/WebSocket connects to the independent Go relay, which does not hold client E2EE keys. No graphical client or Dart/Rust bridge exists yet.
+CLI → `arveil-app` → `arveil-core`; the planned Flutter/bridge will call the same application layer. `arveil-app` coordinates operations and returns structured results; core retains identity, MLS, persistence and delivery primitives. Noise/WebSocket connects to the independent Go relay, which does not hold client E2EE keys. A Flutter client and its bridge now exist and open, query and close a profile; no messaging interface does.
 
 | Change | Implementation and verification |
 |---|---|
@@ -26,7 +26,7 @@ GUI and CLI may alternate ownership, not access the profile concurrently. Future
 
 ## Test provenance
 
-The last workspace `cargo test --workspace --locked` run passed 72 tests, including a helper process test, with one ignored; demo, interop, q3-capture and phases 1–4 also ran locally. `git diff --check` passed. These are local-checkout results at that time, not cross-platform or remote CI certification.
+The last workspace `cargo test --workspace --locked` run passed 72 tests, including a helper process test, with one ignored; demo, interop, q3-capture and phases 1–4 also ran locally. The M3b.0 acceptance flow ran on the device on macOS and on an Android emulator (Android 15, API 35, arm64); no physical phone yet. The [platform matrix](PLATFORMS.md) records the pinned toolchain and the commands. `git diff --check` passed. These are local-checkout results at that time, not cross-platform or remote CI certification.
 
 Coverage includes `overlapping_pairing_confirmations_share_one_mailbox_and_route`, `direct_grant_completion_resumes_after_network_failure`, and `late_response_cannot_contaminate_a_second_request`. [Application lock tests](https://github.com/Ulzuhan/arveil/blob/main/core/crates/arveil-app/tests/profile_lock.rs) cover normal closure, abrupt termination, distinct profiles and Unix symlink aliases; [CLI tests](https://github.com/Ulzuhan/arveil/blob/main/core/crates/arveil-cli/tests/profile_lock.rs) cover legacy protection.
 
@@ -34,7 +34,7 @@ The implementer also reported Clippy and phases 1–4 passing in earlier iterati
 
 ## Remaining limits
 
-- No GUI, Flutter bindings, graphical installers or physical mobile validation.
+- The graphical client opens, queries and closes a profile and nothing else: enrollment, pairing, conversation, attachments and device management have no interface. No graphical installers, and no validation on a physical mobile device.
 - Only the CLI reads environment variables now, and it still chooses an unencrypted profile when no key is set. Platform key stores remain pending (M3b.1).
 - Blocking API requires an asynchronous Dart adapter. Events return at operation completion; streaming and general cancellation need contracts.
 - File/membership events need further correlation identifiers; history needs pagination.

--- a/docs/PHASE3B.md
+++ b/docs/PHASE3B.md
@@ -6,7 +6,7 @@ The [Spanish plan](es/PHASE3B.md) is the normative source of acceptance criteria
 
 ## Scope and structure
 
-Deliver a usable macOS/Android beta for enrollment, pairing and conversation, including offline work and understandable errors. Extend the same Flutter application to Windows, Linux and iOS. No GUI exists yet. SwiftUI, UniFFI, calls, federation, protocol redesign and GUI/CLI IPC are outside this phase's initial scope.
+Deliver a usable macOS/Android beta for enrollment, pairing and conversation, including offline work and understandable errors. Extend the same Flutter application to Windows, Linux and iOS. Today the client opens, queries and closes a profile and has no messaging interface. SwiftUI, UniFFI, calls, federation, protocol redesign and GUI/CLI IPC are outside this phase's initial scope.
 
 ```text
 clients/flutter/             Adaptive UI and platform adapters

--- a/docs/PLATFORMS.md
+++ b/docs/PLATFORMS.md
@@ -1,0 +1,73 @@
+# Platform matrix
+
+What is pinned, what was built, and what was actually run. [Versión española](es/PLATFORMS.md).
+
+A platform counts as **tested** only where the acceptance flow ran on that system. Compiling for a target proves the toolchain, not the product; distribution is a separate claim that nothing here makes yet.
+
+## Pinned toolchain
+
+| Component | Version | Where it is pinned |
+|---|---|---|
+| Rust toolchain | 1.98.1 | `core/rust-toolchain.toml` |
+| Flutter SDK | 3.44.1 (stable channel) | this document, until CI pins it |
+| Dart | 3.12.1 | bundled with the Flutter SDK |
+| flutter_rust_bridge | 2.13.0 (runtime and generator) | `core/crates/arveil-flutter/Cargo.toml` (`=2.13.0`) |
+| Android NDK | 28.2.13676358, minimum API 24 | Android SDK installation |
+| Android SDK | 36.1.0 | Android SDK installation |
+| Xcode | 26.6 | host installation |
+| `openssl-src` | 300.6.1+3.6.3 | `core/Cargo.lock` |
+| `libsqlite3-sys` | 0.38.2 (`bundled-sqlcipher-vendored-openssl`) | `core/Cargo.lock` |
+
+## Matrix
+
+| Platform | Rust target | Built | Tested | Distributed |
+|---|---|---|---|---|
+| macOS (Apple silicon) | `aarch64-apple-darwin` | yes | yes — acceptance run on the host | no |
+| Android | `aarch64-linux-android`, `x86_64-linux-android` | yes — application and bridge | emulator only — Android 15 (API 35), arm64; no physical device yet | no |
+| iOS | `aarch64-apple-ios` | core and application layer only | no | no |
+| Linux | — | no | no | no |
+| Windows | — | no | no | no |
+
+SQLCipher and its vendored OpenSSL cross-compile for Android without the fallback ADR-009 kept in reserve: the built objects are `elf64-littleaarch64` for both `libcrypto` and `sqlite3`.
+
+## Reproducing it
+
+The Rust workspace, on the host:
+
+```bash
+cargo fmt --all --manifest-path core/Cargo.toml -- --check
+cargo clippy --manifest-path core/Cargo.toml --workspace --all-targets --locked -- -D warnings
+cargo test --manifest-path core/Cargo.toml --workspace --locked
+```
+
+Cross-compiling the application layer for Android, with the NDK toolchain named explicitly:
+
+```bash
+NDK=$HOME/Library/Android/sdk/ndk/28.2.13676358
+BIN=$NDK/toolchains/llvm/prebuilt/darwin-x86_64/bin
+ANDROID_NDK_ROOT=$NDK PATH="$BIN:$PATH" \
+  CC_aarch64_linux_android=$BIN/aarch64-linux-android24-clang \
+  AR_aarch64_linux_android=$BIN/llvm-ar \
+  CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER=$BIN/aarch64-linux-android24-clang \
+  cargo build --manifest-path core/Cargo.toml -p arveil-app --target aarch64-linux-android --locked
+```
+
+Regenerating the bindings, from `core/crates/arveil-flutter`:
+
+```bash
+flutter_rust_bridge_codegen generate
+```
+
+The client, from `clients/flutter`:
+
+```bash
+flutter analyze
+flutter test integration_test/profile_test.dart -d macos
+flutter build apk --debug --target-platform android-arm64
+```
+
+## What the acceptance run covers
+
+`integration_test/profile_test.dart` runs on the device itself: a profile opens with an explicit 64-hexadecimal-character key, a query answers with a typed `Domain` failure naming `query-conversations` because a fresh profile has no device yet, a second independent open is refused with `AlreadyOpen`, a malformed key is refused with `BadKey` before anything is created, and after `close` the same directory opens again while a wrong key fails at open with `Unusable`.
+
+Record every run against a commit, an operating system and a device. A run on an emulator is written down as an emulator run: it exercises the same binaries, not the same hardware, and M3b.5 still owes a physical device.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Arveil — architecture documentation
 
-**Current client status:** see the [implemented client foundation](CLIENT_FOUNDATION.md), [Flutter implementation plan](PHASE3B.md) and [accepted ADR-009](adr/ADR-009-flutter-first.md). These updates supersede the earlier client proposals below. Flutter is selected; `mls-rs` is already in use. No graphical client exists yet. Earlier unresolved-item lists are historical, not the current backlog.
+**Current client status:** see the [implemented client foundation](CLIENT_FOUNDATION.md), [Flutter implementation plan](PHASE3B.md) and [accepted ADR-009](adr/ADR-009-flutter-first.md). These updates supersede the earlier client proposals below. Flutter is selected; `mls-rs` is already in use. A Flutter client opens, queries and closes a profile through the Rust core, verified on macOS; there is no messaging interface yet. Earlier unresolved-item lists are historical, not the current backlog.
 
 **Status:** design proposal v0.4 · **Date:** 2026-09-04 · **Language:** English.
 

--- a/docs/adr/ADR-009-flutter-first.md
+++ b/docs/adr/ADR-009-flutter-first.md
@@ -1,6 +1,6 @@
 # ADR-009: Flutter first, shared Rust core
 
-Status: accepted implementation direction; GUI not implemented. [Versión española](../es/adr/ADR-009-flutter-first.md).
+Status: accepted implementation direction; the adapter and a technical client exist, the messaging interface does not. [Versión española](../es/adr/ADR-009-flutter-first.md).
 
 ## Context
 

--- a/docs/es/CLIENT_FOUNDATION.md
+++ b/docs/es/CLIENT_FOUNDATION.md
@@ -11,7 +11,7 @@ Flutter → puente Rust (pendientes) ─┴→ arveil-app → arveil-core
                                       └→ transporte Noise/WebSocket → relay Go
 ```
 
-`arveil-app` coordina operaciones y devuelve resultados estructurados. `arveil-core` conserva identidad, MLS, persistencia y primitivas de entrega. El relay sigue siendo un proceso Go independiente; no contiene las claves E2EE de los clientes. No existe todavía cliente gráfico ni puente Dart/Rust.
+`arveil-app` coordina operaciones y devuelve resultados estructurados. `arveil-core` conserva identidad, MLS, persistencia y primitivas de entrega. El relay sigue siendo un proceso Go independiente; no contiene las claves E2EE de los clientes. Ya existen cliente Flutter y puente: abren, consultan y cierran un perfil. No existe interfaz de mensajería.
 
 ## Cambios realizados y evidencia
 
@@ -38,7 +38,7 @@ Los enlaces a código siguen `main` del repositorio; este registro local debe in
 
 ## Evidencia de revisión
 
-La última ejecución de `cargo test --workspace --locked` terminó con 72 pruebas correctas (incluida una prueba auxiliar de procesos) y una ignorada; demo, interop, q3-capture y las fases 1–4 también se ejecutaron en local. `git diff --check` pasó. Es un resultado del checkout local en ese momento, no una afirmación sobre todas las plataformas o la CI remota.
+La última ejecución de `cargo test --workspace --locked` terminó con 72 pruebas correctas (incluida una prueba auxiliar de procesos) y una ignorada; demo, interop, q3-capture y las fases 1–4 también se ejecutaron en local. La aceptación de M3b.0 se ejecutó sobre el propio sistema en macOS y en un emulador Android (Android 15, API 35, arm64); todavía sin teléfono físico. La [matriz de plataformas](PLATFORMS.md) recoge el toolchain fijado y los comandos. `git diff --check` pasó. Es un resultado del checkout local en ese momento, no una afirmación sobre todas las plataformas o la CI remota.
 
 Pruebas destacadas:
 
@@ -51,7 +51,7 @@ El implementador informó además de Clippy y fases 1–4 correctos durante las 
 
 ## Límites que permanecen
 
-- No hay GUI, bindings Flutter, instaladores gráficos ni validación del cliente en dispositivos móviles.
+- El cliente gráfico abre, consulta y cierra un perfil y nada más: alta, emparejamiento, conversación, adjuntos y gestión de dispositivos no tienen interfaz. No hay instaladores gráficos ni validación en un dispositivo móvil físico.
 - Solo la CLI lee ya variables de entorno, y sigue eligiendo perfil sin cifrar cuando no hay clave. La integración con los almacenes de claves del sistema sigue pendiente (M3b.1).
 - La API bloqueante necesita un adaptador asíncrono para Dart. Los eventos se devuelven por operación; una suscripción continua y cancelación general todavía requieren contrato.
 - Algunos eventos de archivos y membresía necesitan identificadores adicionales para actualizar elementos concretos de la UI. Las consultas de historial necesitan paginación para uso continuado.

--- a/docs/es/PHASE3B.md
+++ b/docs/es/PHASE3B.md
@@ -8,7 +8,7 @@ Estado: plan aprobado en dirección, implementación pendiente. Orden de ejecuci
 
 Una beta que permita a dos personas instalar Arveil, crear o vincular su identidad y conversar desde macOS y Android, incluyendo trabajo sin conexión y errores comprensibles. La misma base Flutter se ampliará a Windows, Linux e iOS.
 
-No incluye SwiftUI, UniFFI, federación, llamadas, IPC entre GUI y CLI ni rediseño del protocolo. Todavía no existe cliente gráfico. Los hitos siguientes empiezan pendientes.
+No incluye SwiftUI, UniFFI, federación, llamadas, IPC entre GUI y CLI ni rediseño del protocolo. El cliente gráfico existente abre, consulta y cierra un perfil; no hay ninguna pantalla de mensajería.
 
 ## Estructura prevista
 

--- a/docs/es/PLATFORMS.md
+++ b/docs/es/PLATFORMS.md
@@ -1,0 +1,73 @@
+# Matriz de plataformas
+
+Qué está fijado, qué se ha compilado y qué se ha ejecutado de verdad. [English version](../PLATFORMS.md).
+
+Una plataforma cuenta como **probada** solo donde el flujo de aceptación se ejecutó en ese sistema. Compilar para un target demuestra el toolchain, no el producto; la distribución es una afirmación distinta que aquí todavía no se hace.
+
+## Toolchain fijado
+
+| Componente | Versión | Dónde se fija |
+|---|---|---|
+| Toolchain de Rust | 1.98.1 | `core/rust-toolchain.toml` |
+| SDK de Flutter | 3.44.1 (canal stable) | este documento, hasta que lo fije CI |
+| Dart | 3.12.1 | incluido en el SDK de Flutter |
+| flutter_rust_bridge | 2.13.0 (runtime y generador) | `core/crates/arveil-flutter/Cargo.toml` (`=2.13.0`) |
+| NDK de Android | 28.2.13676358, API mínima 24 | instalación del SDK de Android |
+| SDK de Android | 36.1.0 | instalación del SDK de Android |
+| Xcode | 26.6 | instalación del anfitrión |
+| `openssl-src` | 300.6.1+3.6.3 | `core/Cargo.lock` |
+| `libsqlite3-sys` | 0.38.2 (`bundled-sqlcipher-vendored-openssl`) | `core/Cargo.lock` |
+
+## Matriz
+
+| Plataforma | Target de Rust | Compilado | Probado | Distribuido |
+|---|---|---|---|---|
+| macOS (Apple silicon) | `aarch64-apple-darwin` | sí | sí — aceptación ejecutada en el anfitrión | no |
+| Android | `aarch64-linux-android`, `x86_64-linux-android` | sí — aplicación y puente | solo emulador — Android 15 (API 35), arm64; falta dispositivo físico | no |
+| iOS | `aarch64-apple-ios` | solo núcleo y capa de aplicación | no | no |
+| Linux | — | no | no | no |
+| Windows | — | no | no | no |
+
+SQLCipher y su OpenSSL vendorizado cruzan a Android sin recurrir a la alternativa que ADR-009 dejó en reserva: los objetos resultantes son `elf64-littleaarch64` tanto para `libcrypto` como para `sqlite3`.
+
+## Cómo reproducirlo
+
+El workspace de Rust, en el anfitrión:
+
+```bash
+cargo fmt --all --manifest-path core/Cargo.toml -- --check
+cargo clippy --manifest-path core/Cargo.toml --workspace --all-targets --locked -- -D warnings
+cargo test --manifest-path core/Cargo.toml --workspace --locked
+```
+
+Compilación cruzada de la capa de aplicación para Android, nombrando el toolchain del NDK de forma explícita:
+
+```bash
+NDK=$HOME/Library/Android/sdk/ndk/28.2.13676358
+BIN=$NDK/toolchains/llvm/prebuilt/darwin-x86_64/bin
+ANDROID_NDK_ROOT=$NDK PATH="$BIN:$PATH" \
+  CC_aarch64_linux_android=$BIN/aarch64-linux-android24-clang \
+  AR_aarch64_linux_android=$BIN/llvm-ar \
+  CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER=$BIN/aarch64-linux-android24-clang \
+  cargo build --manifest-path core/Cargo.toml -p arveil-app --target aarch64-linux-android --locked
+```
+
+Regeneración de los bindings, desde `core/crates/arveil-flutter`:
+
+```bash
+flutter_rust_bridge_codegen generate
+```
+
+El cliente, desde `clients/flutter`:
+
+```bash
+flutter analyze
+flutter test integration_test/profile_test.dart -d macos
+flutter build apk --debug --target-platform android-arm64
+```
+
+## Qué cubre la aceptación
+
+`integration_test/profile_test.dart` se ejecuta en el propio sistema: un perfil abre con clave explícita de 64 caracteres hexadecimales, una consulta responde con un fallo tipado `Domain` que nombra `query-conversations` porque un perfil recién creado no tiene dispositivo, una segunda apertura independiente se rechaza con `AlreadyOpen`, una clave mal formada se rechaza con `BadKey` antes de crear nada, y tras `close` el mismo directorio vuelve a abrir mientras una clave incorrecta falla en la apertura con `Unusable`.
+
+Registrar cada ejecución contra un commit, un sistema operativo y un dispositivo. Una ejecución en emulador se anota como emulador: ejercita los mismos binarios, no el mismo hardware, y M3b.5 sigue debiendo un dispositivo físico.

--- a/docs/es/README.md
+++ b/docs/es/README.md
@@ -1,6 +1,6 @@
 # Arveil — documentación de arquitectura
 
-**Estado actual del cliente:** la [base implementada](CLIENT_FOUNDATION.md), el [plan Flutter](PHASE3B.md) y la [ADR-009 aceptada](adr/ADR-009-flutter-first.md) actualizan las propuestas anteriores. Flutter está elegido y `mls-rs` ya se utiliza. Todavía no existe cliente gráfico. Las listas históricas de cuestiones abiertas que aparecen más abajo no son el backlog actual.
+**Estado actual del cliente:** la [base implementada](CLIENT_FOUNDATION.md), el [plan Flutter](PHASE3B.md) y la [ADR-009 aceptada](adr/ADR-009-flutter-first.md) actualizan las propuestas anteriores. Flutter está elegido y `mls-rs` ya se utiliza. Existe un cliente Flutter que abre, consulta y cierra un perfil a través del núcleo Rust, verificado en macOS; todavía no hay interfaz de mensajería. Las listas históricas de cuestiones abiertas que aparecen más abajo no son el backlog actual.
 
 **Estado:** propuesta de diseño v0.4 · **Fecha:** 2026-09-04 · **Idioma:** español.
 

--- a/docs/es/adr/ADR-009-flutter-first.md
+++ b/docs/es/adr/ADR-009-flutter-first.md
@@ -1,6 +1,6 @@
 # ADR-009: Flutter primero, núcleo Rust compartido
 
-Estado: aceptada como dirección de implementación; GUI todavía no implementada.
+Estado: aceptada como dirección de implementación; el adaptador y un cliente técnico existen, la interfaz de mensajería no.
 
 [English version](../../adr/ADR-009-flutter-first.md).
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,6 +64,7 @@ nav:
   - Phase 3 plan: PHASE3.md
   - Client foundation: CLIENT_FOUNDATION.md
   - Flutter plan (phase 3b): PHASE3B.md
+  - Platform matrix: PLATFORMS.md
   - Phase 4 plan: PHASE4.md
   - Decision records:
       - ADR-001 Go server, Rust core: adr/ADR-001-go-server-rust-core.md
@@ -89,6 +90,7 @@ nav:
       - Arquitectura: es/ARCHITECTURE.md
       - Base de aplicación implementada: es/CLIENT_FOUNDATION.md
       - Plan Flutter (fase 3b): es/PHASE3B.md
+      - Matriz de plataformas: es/PLATFORMS.md
       - ADR-009 Flutter primero: es/adr/ADR-009-flutter-first.md
       - Modelo de amenazas: es/THREAT_MODEL.md
       - Protocolo: es/PROTOCOL.md


### PR DESCRIPTION
Closes the remaining M3b.0 work: Android acceptance, native builds in CI, the platform matrix, and documentation that matches what exists.

## Android

`flutter test integration_test/profile_test.dart -d emulator-5554` passes on Android 15 (API 35, arm64): explicit key, typed `Domain` failure from a query, `AlreadyOpen`, `BadKey`, close, reopen, wrong key → `Unusable`. Same test as macOS.

Recorded as an **emulator** run. An emulator exercises the same binaries, not the same hardware; M3b.5 still owes a physical phone.

## CI

Two new jobs, so cross-compilation stops depending on one laptop:

- `Flutter bridge (macOS)` — `flutter analyze` plus a debug application build, which links the adapter and therefore builds SQLCipher and its vendored OpenSSL.
- `Flutter bridge (Android)` — a debug APK for one ABI. One vendored OpenSSL pass proves the toolchain; the release ABI matrix is a packaging question for M3b.5.

FRB regeneration drift is not checked yet — the plan places it in M3b.1.

## Platform matrix

`docs/PLATFORMS.md` (both languages) pins the toolchain, separates **built** from **tested** from **distributed**, and carries the commands for each column. No row claims distribution.

## Documentation

Eight places said no graphical client existed. One does now — it opens, queries and closes a profile — and those eight places say that instead, along with what it still cannot do. The client README replaces the Flutter template.

## Verification

`cargo fmt --check` clean, `mkdocs build --strict` clean, macOS and Android acceptance passing locally. The Rust suite and Clippy are unchanged by this branch and run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
