### PR TITLE
relay: refuse a future schema before touching the database, not after

### DIFF
--- a/relay/internal/store/store.go
+++ b/relay/internal/store/store.go
@@ -21,16 +21,16 @@ import (
 const MinSQLiteVersionNumber = 3051003
 
 var (
-	ErrInviteInvalid   = errors.New("invite: unknown, expired or exhausted")
-	ErrAlreadyMember   = errors.New("membership: identity already a member")
-	ErrDeviceKeyInUse  = errors.New("credential: transport key already registered")
+	ErrInviteInvalid  = errors.New("invite: unknown, expired or exhausted")
+	ErrAlreadyMember  = errors.New("membership: identity already a member")
+	ErrDeviceKeyInUse = errors.New("credential: transport key already registered")
 	// ErrAlreadyRedeemed reports a repeat of a redemption this store already
 	// performed for the same token, identity and credential. It is not a
 	// failure: the caller answers with the result it recorded the first time.
 	ErrAlreadyRedeemed = errors.New("invite: already redeemed by this credential")
 	// ErrSchemaTooNew reports a database written by a newer relay. Nothing
 	// is modified: an older binary cannot know what it would break.
-	ErrSchemaTooNew = errors.New("schema: written by a newer relay")
+	ErrSchemaTooNew    = errors.New("schema: written by a newer relay")
 	ErrManifestOrder   = errors.New("manifest: sequence must exceed the stored one")
 	ErrUnknownIdentity = errors.New("membership: unknown identity")
 )
@@ -113,6 +113,14 @@ func Open(path string) (*Store, error) {
 		db.Close()
 		return nil, err
 	}
+	// Before the pragmas and before the schema: refusing a database after
+	// writing to it is not refusing it. A pragma alone can rewrite the file
+	// header, and `CREATE TABLE IF NOT EXISTS` is still a modification of a
+	// database this binary just said it does not understand.
+	if err := s.refuseFutureSchema(); err != nil {
+		db.Close()
+		return nil, err
+	}
 	if _, err := db.Exec(pragmas); err != nil {
 		db.Close()
 		return nil, fmt.Errorf("pragmas: %w", err)
@@ -181,18 +189,28 @@ func (s *Store) checkVersion() error {
 // newer one is refused rather than guessed at.
 const SchemaVersion = 2
 
-// recordSchemaVersion refuses a database from a newer relay before touching
-// anything, and otherwise records that this version has been applied.
-func (s *Store) recordSchemaVersion() error {
+// refuseFutureSchema reads the recorded version and refuses a database from
+// a newer relay. It reads only: a database with no `schema_migrations` table
+// is a fresh one, not an unreadable one.
+func (s *Store) refuseFutureSchema() error {
 	var highest sql.NullInt64
-	if err := s.db.QueryRow(`SELECT MAX(version) FROM schema_migrations`).Scan(&highest); err != nil {
+	err := s.db.QueryRow(`SELECT MAX(version) FROM schema_migrations`).Scan(&highest)
+	switch {
+	case err != nil && strings.Contains(err.Error(), "no such table"):
+		return nil
+	case err != nil:
 		return err
-	}
-	if highest.Valid && highest.Int64 > SchemaVersion {
+	case highest.Valid && highest.Int64 > SchemaVersion:
 		return fmt.Errorf(
 			"%w: the database is at version %d and this relay understands %d",
 			ErrSchemaTooNew, highest.Int64, SchemaVersion)
 	}
+	return nil
+}
+
+// recordSchemaVersion notes that this version has been applied. The refusal
+// happened before anything was written; this only records what was done.
+func (s *Store) recordSchemaVersion() error {
 	_, err := s.db.Exec(
 		`INSERT OR IGNORE INTO schema_migrations (version, applied_at) VALUES (?, ?)`,
 		SchemaVersion, time.Now().Unix())

--- a/relay/internal/store/store_test.go
+++ b/relay/internal/store/store_test.go
@@ -1,8 +1,11 @@
 package store
 
 import (
+	"bytes"
 	"context"
+	"database/sql"
 	"errors"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -84,6 +87,66 @@ func TestRedeemInviteRefusesAnotherCredentialForTheSameIdentity(t *testing.T) {
 	other.TransportKey = []byte{9, 5}
 	if err := s.RedeemInvite(ctx, token, now, other, nil); !errors.Is(err, ErrAlreadyMember) {
 		t.Fatalf("another credential should conflict, got %v", err)
+	}
+}
+
+func TestOpenChangesNothingWhenItRefusesAFutureSchema(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "relay.db")
+
+	// A database that is ours and from the future, deliberately missing a
+	// table this binary would otherwise create for it.
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`CREATE TABLE schema_migrations (
+        version    INTEGER PRIMARY KEY,
+        applied_at INTEGER NOT NULL
+    )`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO schema_migrations (version, applied_at) VALUES (?, ?)`,
+		SchemaVersion+1, time.Now().Unix()); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := Open(path); !errors.Is(err, ErrSchemaTooNew) {
+		t.Fatalf("expected a refusal, got %v", err)
+	}
+
+	// Refusing after writing is not refusing. The file is byte for byte
+	// what it was, and the tables this binary would have created are not
+	// there.
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatal("the database was modified before being refused")
+	}
+
+	reopened, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reopened.Close()
+	var tables int
+	if err := reopened.QueryRow(
+		`SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name != 'schema_migrations'`,
+	).Scan(&tables); err != nil {
+		t.Fatal(err)
+	}
+	if tables != 0 {
+		t.Fatalf("%d tables were created in a database that was refused", tables)
 	}
 }
 


### PR DESCRIPTION
Follow-up to #64, which added the version check in the wrong place.

## The bug

`refuseFutureSchema` ran **after** `db.Exec(pragmas)` and `db.Exec(schema)`. A database written by a newer relay was therefore modified — pragmas can rewrite the file header, and `CREATE TABLE IF NOT EXISTS` adds tables — and only then refused. Refusing after writing is not refusing.

## The fix

The version is read first, and read only. A database with no `schema_migrations` table is treated as fresh rather than unreadable, so a first start still works.

## The regression

`TestOpenChangesNothingWhenItRefusesAFutureSchema` opens a future-version database deliberately missing a table this binary would create, then asserts:

- the error is `ErrSchemaTooNew`;
- the file is **byte for byte** what it was;
- no table appeared.

Checked against the old ordering: it fails on the first assertion ("the database was modified before being refused"). It passes with the fix.

Relay suite green under `-race`; interop and phase 4 green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)